### PR TITLE
Replace illuminate/support with tightenco/collect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
 
   "require": {
     "php": "^7.0",
-    "illuminate/support": "5.5.*|5.6.*",
-    "maxakawizard/json-collection-parser": "^1.1"
+    "maxakawizard/json-collection-parser": "^1.1",
+    "tightenco/collect": "^5.5.33"
   },
 
   "require-dev": {

--- a/src/Parsers/CSVParser.php
+++ b/src/Parsers/CSVParser.php
@@ -9,9 +9,9 @@
 namespace Rodenastyle\StreamParser\Parsers;
 
 
-use Illuminate\Support\Collection;
 use Rodenastyle\StreamParser\Exceptions\IncompleteParseException;
 use Rodenastyle\StreamParser\StreamParserInterface;
+use Tightenco\Collect\Support\Collection;
 
 class CSVParser implements StreamParserInterface
 {

--- a/src/Parsers/JSONParser.php
+++ b/src/Parsers/JSONParser.php
@@ -11,7 +11,7 @@ namespace Rodenastyle\StreamParser\Parsers;
 
 use Rodenastyle\StreamParser\Services\JsonCollectionParser as Parser;
 use Rodenastyle\StreamParser\StreamParserInterface;
-use Illuminate\Support\Collection;
+use Tightenco\Collect\Support\Collection;
 
 class JSONParser implements StreamParserInterface
 {

--- a/src/Parsers/XMLParser.php
+++ b/src/Parsers/XMLParser.php
@@ -11,8 +11,8 @@ namespace Rodenastyle\StreamParser\Parsers;
 
 use Rodenastyle\StreamParser\Exceptions\IncompleteParseException;
 use Rodenastyle\StreamParser\StreamParserInterface;
+use Tightenco\Collect\Support\Collection;
 use XMLReader;
-use Illuminate\Support\Collection;
 
 
 class XMLParser implements StreamParserInterface

--- a/tests/Parsers/CSVParserTest.php
+++ b/tests/Parsers/CSVParserTest.php
@@ -10,7 +10,7 @@ namespace Rodenastyle\StreamParser\Test\Parsers;
 
 use PHPUnit\Framework\TestCase;
 use Rodenastyle\StreamParser\StreamParser;
-use Illuminate\Support\Collection;
+use Tightenco\Collect\Support\Collection;
 
 class CSVParserTest extends TestCase
 {

--- a/tests/Parsers/JSONParserTest.php
+++ b/tests/Parsers/JSONParserTest.php
@@ -10,7 +10,7 @@ namespace Rodenastyle\StreamParser\Test\Parsers;
 
 use Rodenastyle\StreamParser\Test\TestCase;
 use Rodenastyle\StreamParser\StreamParser;
-use Illuminate\Support\Collection;
+use Tightenco\Collect\Support\Collection;
 
 class JSONParserTest extends TestCase
 {

--- a/tests/Parsers/XMLParserTest.php
+++ b/tests/Parsers/XMLParserTest.php
@@ -8,11 +8,11 @@
 
 namespace Rodenastyle\StreamParser\Test\Parsers;
 
-use Illuminate\Support\Collection;
 use Rodenastyle\StreamParser\StreamParser;
 use Rodenastyle\StreamParser\Test\Contracts\ElementAttributesManagement;
 use Rodenastyle\StreamParser\Test\Contracts\ElementListManagement;
 use Rodenastyle\StreamParser\Test\TestCase;
+use Tightenco\Collect\Support\Collection;
 
 class XMLParserTest extends TestCase implements ElementAttributesManagement, ElementListManagement {
 


### PR DESCRIPTION
Replacing the `illuminate/support` package with `tightenco/collect` reduces the amount of pulled in dependencies and other drawbacks ([Why not pull Illuminate\Support in framework-agnostic packages](http://mattallan.org/posts/dont-use-illuminate-support/)).

:octocat: 