### PR TITLE
Using new Collection() instead of collect()

### DIFF
--- a/src/Parsers/CSVParser.php
+++ b/src/Parsers/CSVParser.php
@@ -52,7 +52,7 @@ class CSVParser implements StreamParserInterface
 		$this->reader = fopen($this->source, 'r');
 
 		$this->read();
-		$this->headers = collect($this->currentLine);
+		$this->headers = new Collection($this->currentLine);
 
 		return $this;
 	}
@@ -64,7 +64,7 @@ class CSVParser implements StreamParserInterface
 	}
 
 	private function read(): bool{
-		$this->currentLine = collect(fgetcsv($this->reader))->filter();
+		$this->currentLine = (new Collection(fgetcsv($this->reader)))->filter();
 		return $this->currentLine->isNotEmpty();
 	}
 
@@ -83,13 +83,13 @@ class CSVParser implements StreamParserInterface
 
 	private function explodeCollectionValues(Collection $collection){
 		$collection->transform(function($value){
-			collect(static::$delimiters)->each(function($delimiter) use (&$value){
+			(new Collection(static::$delimiters))->each(function($delimiter) use (&$value){
 				if( ! is_array($value) && strpos($value, $delimiter) !== false){
 					$value = explode($delimiter, $value);
 				}
 			});
 			if(is_array($value)){
-				return collect($value)->reject(function($value){
+				return (new Collection($value))->reject(function($value){
 					return empty($value);
 				});
 			} else {

--- a/src/Parsers/JSONParser.php
+++ b/src/Parsers/JSONParser.php
@@ -40,7 +40,7 @@ class JSONParser implements StreamParserInterface
 	{
 		$this->start();
 		$this->reader->parse($this->source, function(array $item) use ($function){
-			$function(collect($item)->recursive());
+			$function((new Collection($item))->recursive());
 		});
 	}
 

--- a/src/Parsers/XMLParser.php
+++ b/src/Parsers/XMLParser.php
@@ -68,7 +68,7 @@ class XMLParser implements StreamParserInterface
 			if($this->isElement()){
 				if($couldBeAnElementsList){
 					$foundElementName = $this->reader->name;
-					$elementCollection->push(collect($this->extractElement($foundElementName)));
+					$elementCollection->push(new Collection($this->extractElement($foundElementName)));
 				} else {
 					$foundElementName = $this->reader->name;
 					$elementCollection->put($foundElementName, $this->extractElement($foundElementName, true));


### PR DESCRIPTION
When using this package in a Laravel project the collect() returns an instance of `Illuminate\Support\Collection` instead of an instance of `Tightenco\Collect\Support\Collection` and throw a error like:

Argument 1 passed to `Rodenastyle\StreamParser\Parsers\CSVParser::formatCurrentLineValues()` must be an instance of `Tightenco\Collect\Support\Collection`, instance of `Illuminate\Support\Collection` given

This PR changes the `collect()` to `new Collection()` to explicitly get the `Tightenco\Collect\Support\Collection` as expected.