### PR TITLE
Parse in chunks and stop the parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,42 @@ StreamParser::xml("https://example.com/users.xml")->each(function(Collection $us
 });
 ```
 
+It is also possible to parse in chunks:
+```php
+use Tightenco\Collect\Support\Collection;
+
+StreamParser::xml("https://example.com/users.xml")->chunk(20, function(Collection $users){
+    doSomething($users);
+});
+```
+
+Return `false` if want to stop the parser
+```php
+use Tightenco\Collect\Support\Collection;
+
+StreamParser::xml("https://example.com/users.xml")->each(function(Collection $user){
+    if($something) {
+        return false;
+    }
+});
+```
+
+Or throw a `\Rodenastyle\StreamParser\Exceptions\StopParseException`
+```php
+use Tightenco\Collect\Support\Collection;
+use Rodenastyle\StreamParser\Exceptions\StopParseException;
+
+function doSomething($user) {
+    if($something) {
+        throw new StopParseException();
+    }
+}
+
+StreamParser::xml("https://example.com/users.xml")->each(function(Collection $user){
+    doSomething($user);
+});
+```
+
 ## Practical Input/Code/Output demos
 
 ### XML

--- a/src/Exceptions/StopParseException.php
+++ b/src/Exceptions/StopParseException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Rodenastyle\StreamParser\Exceptions;
+
+class StopParseException extends \Exception
+{}

--- a/src/Parsers/CSVParser.php
+++ b/src/Parsers/CSVParser.php
@@ -10,6 +10,7 @@ namespace Rodenastyle\StreamParser\Parsers;
 
 
 use Rodenastyle\StreamParser\Exceptions\IncompleteParseException;
+use Rodenastyle\StreamParser\Exceptions\StopParseException;
 use Rodenastyle\StreamParser\StreamParserInterface;
 use Tightenco\Collect\Support\Collection;
 
@@ -41,10 +42,16 @@ class CSVParser implements StreamParserInterface
 	public function each(callable $function)
 	{
 		$this->start();
-		while($this->read()){
-			$function($this->getCurrentLineAsCollection());
+		try {
+			while($this->read()){
+				if($function($this->getCurrentLineAsCollection()) === false) {
+					break;
+				}
+			}
+		} catch (StopParseException $e) {
+		} finally {
+			$this->close();
 		}
-		$this->close();
 	}
 
 	private function start()

--- a/src/Parsers/CSVParser.php
+++ b/src/Parsers/CSVParser.php
@@ -54,6 +54,39 @@ class CSVParser implements StreamParserInterface
 		}
 	}
 
+	public function chunk($count, callable $function)
+	{
+		if($count <= 0) {
+			return;
+		}
+
+		$this->start();
+		try {
+			$chunk = new Collection();
+
+			while($this->read()){
+				$chunk->push($this->getCurrentLineAsCollection());
+
+				if($chunk->count() >= $count) {
+					$stop = $function($chunk) === false;
+
+					$chunk = new Collection();
+
+					if($stop) {
+						break;
+					}
+				}
+			}
+
+			if($chunk->count() > 0) {
+				$function($chunk);
+			}
+		} catch (StopParseException $e) {
+		} finally {
+			$this->close();
+		}
+	}
+
 	private function start()
 	{
 		$this->reader = fopen($this->source, 'r');

--- a/src/Parsers/JSONParser.php
+++ b/src/Parsers/JSONParser.php
@@ -9,6 +9,7 @@
 namespace Rodenastyle\StreamParser\Parsers;
 
 
+use Rodenastyle\StreamParser\Exceptions\StopParseException;
 use Rodenastyle\StreamParser\Services\JsonCollectionParser as Parser;
 use Rodenastyle\StreamParser\StreamParserInterface;
 use Tightenco\Collect\Support\Collection;
@@ -39,9 +40,14 @@ class JSONParser implements StreamParserInterface
 	public function each(callable $function)
 	{
 		$this->start();
-		$this->reader->parse($this->source, function(array $item) use ($function){
-			$function((new Collection($item))->recursive());
-		});
+		try {
+			$this->reader->parse($this->source, function(array $item) use ($function){
+				if($function((new Collection($item))->recursive()) === false) {
+					throw new StopParseException();
+				}
+			});
+		} catch (StopParseException $e) {
+		}
 	}
 
 	private function start()

--- a/src/Parsers/XMLParser.php
+++ b/src/Parsers/XMLParser.php
@@ -10,6 +10,7 @@ namespace Rodenastyle\StreamParser\Parsers;
 
 
 use Rodenastyle\StreamParser\Exceptions\IncompleteParseException;
+use Rodenastyle\StreamParser\Exceptions\StopParseException;
 use Rodenastyle\StreamParser\StreamParserInterface;
 use Tightenco\Collect\Support\Collection;
 use XMLReader;
@@ -37,16 +38,22 @@ class XMLParser implements StreamParserInterface
 	public function each(callable $function)
 	{
 		$this->start();
-		while($this->reader->read()){
-			$this->searchElement($function);
+		try {
+			while($this->reader->read()){
+				if($this->searchElement($function) === false) {
+					break;
+				}
+			}
+		} catch (StopParseException $e) {
+		} finally {
+			$this->stop();
 		}
-		$this->stop();
 	}
 
 	private function searchElement(callable $function)
 	{
 		if($this->isElement() && ! $this->shouldBeSkipped()){
-			$function($this->extractElement($this->reader->name));
+			return $function($this->extractElement($this->reader->name));
 		}
 	}
 

--- a/src/StreamParserInterface.php
+++ b/src/StreamParserInterface.php
@@ -13,4 +13,5 @@ interface StreamParserInterface
 {
 	public function from(String $source): StreamParserInterface;
 	public function each(callable $function);
+	public function chunk($count, callable $function);
 }

--- a/tests/Contracts/StopParseDetection.php
+++ b/tests/Contracts/StopParseDetection.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rodenastyle\StreamParser\Test\Contracts;
+
+interface StopParseDetection
+{
+	public function test_detects_stop_parse();
+}

--- a/tests/Parsers/CSVParserTest.php
+++ b/tests/Parsers/CSVParserTest.php
@@ -9,6 +9,7 @@
 namespace Rodenastyle\StreamParser\Test\Parsers;
 
 use PHPUnit\Framework\TestCase;
+use Rodenastyle\StreamParser\Exceptions\StopParseException;
 use Rodenastyle\StreamParser\StreamParser;
 use Tightenco\Collect\Support\Collection;
 
@@ -25,6 +26,31 @@ class CSVParserTest extends TestCase
 		});
 
 		$this->assertEquals(5, $count);
+	}
+
+	public function test_detects_stop_parse()
+	{
+		$count = 0;
+
+		StreamParser::csv($this->stub)->each(function() use (&$count){
+			$count++;
+			if($count == 2) {
+				return false;
+			}
+		});
+
+		$this->assertEquals(2, $count);
+
+		$count = 0;
+
+		StreamParser::csv($this->stub)->each(function() use (&$count){
+			$count++;
+			if($count == 2) {
+				throw new StopParseException();
+			}
+		});
+
+		$this->assertEquals(2, $count);
 	}
 
 	public function test_transforms_elements_to_collections()

--- a/tests/Parsers/JSONParserTest.php
+++ b/tests/Parsers/JSONParserTest.php
@@ -9,6 +9,7 @@
 namespace Rodenastyle\StreamParser\Test\Parsers;
 
 use Rodenastyle\StreamParser\Test\TestCase;
+use Rodenastyle\StreamParser\Exceptions\StopParseException;
 use Rodenastyle\StreamParser\StreamParser;
 use Tightenco\Collect\Support\Collection;
 
@@ -25,6 +26,31 @@ class JSONParserTest extends TestCase
 		});
 
 		$this->assertEquals(5, $count);
+	}
+
+	public function test_detects_stop_parse()
+	{
+		$count = 0;
+
+		StreamParser::json($this->stub)->each(function() use (&$count){
+			$count++;
+			if($count == 2) {
+				return false;
+			}
+		});
+
+		$this->assertEquals(2, $count);
+
+		$count = 0;
+
+		StreamParser::json($this->stub)->each(function() use (&$count){
+			$count++;
+			if($count == 2) {
+				throw new StopParseException();
+			}
+		});
+
+		$this->assertEquals(2, $count);
 	}
 
 	public function test_transforms_elements_to_collections()

--- a/tests/Parsers/JSONParserTest.php
+++ b/tests/Parsers/JSONParserTest.php
@@ -26,6 +26,19 @@ class JSONParserTest extends TestCase
 		});
 
 		$this->assertEquals(5, $count);
+
+		// chunk
+
+		$count = 0;
+		$countChunk = 0;
+
+		StreamParser::json($this->stub)->chunk(2, function($books) use (&$count, &$countChunk){
+			$count += $books->count();
+			$countChunk++;
+		});
+
+		$this->assertEquals(5, $count);
+		$this->assertEquals(3, $countChunk);
 	}
 
 	public function test_detects_stop_parse()
@@ -51,12 +64,45 @@ class JSONParserTest extends TestCase
 		});
 
 		$this->assertEquals(2, $count);
+
+		// chunk
+
+		$count = 0;
+
+		StreamParser::json($this->stub)->chunk(2, function() use (&$count){
+			$count++;
+			if($count == 2) {
+				return false;
+			}
+		});
+
+		$this->assertEquals(2, $count);
+
+		$count = 0;
+
+		StreamParser::json($this->stub)->chunk(2, function() use (&$count){
+			$count++;
+			if($count == 2) {
+				throw new StopParseException();
+			}
+		});
+
+		$this->assertEquals(2, $count);
 	}
 
 	public function test_transforms_elements_to_collections()
 	{
 		StreamParser::json($this->stub)->each(function($book){
 			$this->assertInstanceOf(Collection::class, $book);
+		});
+
+		// chunk
+
+		StreamParser::json($this->stub)->chunk(2, function($books){
+			$this->assertInstanceOf(Collection::class, $books);
+			foreach($books as $book) {
+				$this->assertInstanceOf(Collection::class, $book);
+			}
 		});
 	}
 
@@ -73,6 +119,14 @@ class JSONParserTest extends TestCase
 		StreamParser::json($this->stub)->each(function($book) use ($titles){
 			$this->assertContains($book->get('title'), $titles);
 		});
+
+		// chunk
+
+		StreamParser::json($this->stub)->chunk(2, function($books) use ($titles){
+			foreach($books as $book) {
+				$this->assertContains($book->get('title'), $titles);
+			}
+		});
 	}
 
 	public function test_also_transforms_element_childs_to_collections_recursively()
@@ -80,6 +134,16 @@ class JSONParserTest extends TestCase
 		StreamParser::json($this->stub)->each(function($book){
 			if($book->has('comments')){
 				$this->assertInstanceOf(Collection::class, $book->get('comments'));
+			}
+		});
+
+		// chunk
+
+		StreamParser::json($this->stub)->chunk(2, function($books){
+			foreach($books as $book) {
+				if($book->has('comments')){
+					$this->assertInstanceOf(Collection::class, $book->get('comments'));
+				}
 			}
 		});
 	}

--- a/tests/Parsers/XMLParserTest.php
+++ b/tests/Parsers/XMLParserTest.php
@@ -8,6 +8,7 @@
 
 namespace Rodenastyle\StreamParser\Test\Parsers;
 
+use Rodenastyle\StreamParser\Exceptions\StopParseException;
 use Rodenastyle\StreamParser\StreamParser;
 use Rodenastyle\StreamParser\Test\Contracts\ElementAttributesManagement;
 use Rodenastyle\StreamParser\Test\Contracts\ElementListManagement;
@@ -27,6 +28,31 @@ class XMLParserTest extends TestCase implements ElementAttributesManagement, Ele
 		});
 
 		$this->assertEquals(5, $count);
+	}
+
+	public function test_detects_stop_parse()
+	{
+		$count = 0;
+
+		StreamParser::xml($this->stub)->each(function() use (&$count){
+			$count++;
+			if($count == 2) {
+				return false;
+			}
+		});
+
+		$this->assertEquals(2, $count);
+
+		$count = 0;
+
+		StreamParser::xml($this->stub)->each(function() use (&$count){
+			$count++;
+			if($count == 2) {
+				throw new StopParseException();
+			}
+		});
+
+		$this->assertEquals(2, $count);
 	}
 
 	public function test_transforms_elements_to_collections()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,9 +11,11 @@ namespace Rodenastyle\StreamParser\Test;
 use PHPUnit\Framework\TestCase as BaseTest;
 use Rodenastyle\StreamParser\Test\Contracts\ElementToCollectionTransformation;
 use Rodenastyle\StreamParser\Test\Contracts\MainElementsDetection;
+use Rodenastyle\StreamParser\Test\Contracts\StopParseDetection;
 
 abstract class TestCase extends BaseTest
 implements
 	MainElementsDetection,
-	ElementToCollectionTransformation
+	ElementToCollectionTransformation,
+	StopParseDetection
 {}


### PR DESCRIPTION
This PR adds the feature to parse in chunks and stop the parser.

Parse in chunks
```php
use Tightenco\Collect\Support\Collection;

StreamParser::xml("https://example.com/users.xml")->chunk(20, function(Collection $users){
    doSomething($users);
});
```

Return `false` if want to stop the parser
```php
use Tightenco\Collect\Support\Collection;

StreamParser::xml("https://example.com/users.xml")->each(function(Collection $user){
    if($something) {
        return false;
    }
});
```

Or throw a `\Rodenastyle\StreamParser\Exceptions\StopParseException`
```php
use Tightenco\Collect\Support\Collection;
use Rodenastyle\StreamParser\Exceptions\StopParseException;

function doSomething($user) {
    if($something) {
        throw new StopParseException();
    }
}

StreamParser::xml("https://example.com/users.xml")->each(function(Collection $user){
    doSomething($user);
});
```