### PR TITLE
Fix issue #8 file does not exist for url in JSON parser

### DIFF
--- a/src/Services/JsonCollectionParser.php
+++ b/src/Services/JsonCollectionParser.php
@@ -47,4 +47,20 @@ class JsonCollectionParser extends Parser
 			throw new IncompleteParseException();
 		}
 	}
+
+	/**
+	 * @param string $filePath
+	 *
+	 * @return resource
+	 * @throws \Exception
+	 */
+	protected function openFile($filePath)
+	{
+		$stream = @fopen($filePath, 'r');
+		if (false === $stream) {
+			throw new \Exception('Unable to open file for read: ' . $filePath);
+		}
+
+		return $stream;
+	}
 }


### PR DESCRIPTION
This PR fix the issue #8 

The method `openFile()` from `\JsonCollectionParser\Parser` has a check for only allow local files.

This PR override that method to allow external url too.