### PR TITLE
Added chunk processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,5 +148,31 @@ string(29) "I like other versions better."
 string(39) "Excellent overview of world literature."
 ```
 
+### Chunk parsing
+
+```php
+StreamParser::chunk(StreamParser::csv("https://example.com/books.csv")) // CSV with 5 lines
+->setChunkSize(2)
+->eachChunk(function(){
+    var_dump("Chunk complete");
+})
+->each(function($book){
+    var_dump("Line Complete");
+});
+```
+
+```
+string(13) "Line Complete"
+string(13) "Line Complete"
+string(14) "Chunk complete"
+
+string(13) "Line Complete"
+string(13) "Line Complete"
+string(14) "Chunk complete"
+
+string(13) "Line Complete"
+string(14) "Chunk complete"
+```
+
 ## License
 This library is released under [MIT](http://www.tldrlegal.com/license/mit-license) license.

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 
   "require": {
     "php": "^7.0",
+    "ext-xmlreader": "*",
     "maxakawizard/json-collection-parser": "^1.1",
     "tightenco/collect": "^5.5.33"
   },

--- a/src/Exceptions/UndefinedCallbackException.php
+++ b/src/Exceptions/UndefinedCallbackException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Loïc Gouttefangeas <loic.gouttefangeas.pro@gmail.com>
+ * Date: 25/08/2018
+ * Time: 23:55
+ */
+
+namespace Rodenastyle\StreamParser\Exceptions;
+
+
+class UndefinedCallbackException extends \Exception
+{
+
+}

--- a/src/Extensions/ChunkExtension.php
+++ b/src/Extensions/ChunkExtension.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Rodenastyle\StreamParser\Extensions;
+
+use Rodenastyle\StreamParser\Exceptions\UndefinedCallbackException;
+use Rodenastyle\StreamParser\StreamParserInterface;
+
+/**
+ * Created by PhpStorm.
+ * User: Loïc Gouttefangeas <loic.gouttefangeas.pro@gmail.com>
+ * Date: 25/08/2018
+ * Time: 20:59
+ */
+class ChunkExtension implements \Rodenastyle\StreamParser\StreamParserInterface
+{
+    const DEFAULT_CHUNK_SIZE = 5000;
+
+    /**
+     * @var \Rodenastyle\StreamParser\StreamParserInterface
+     */
+    private $parser;
+    private $iterationCount = 0;
+    private $chunkSize;
+    /** @var  callable $onChunkCompleteCallback */
+    private $onChunkCompleteCallback;
+
+    public function __construct(\Rodenastyle\StreamParser\StreamParserInterface $parser, $chunkSize = self::DEFAULT_CHUNK_SIZE)
+    {
+        $this->parser = $parser;
+        $this->chunkSize = $chunkSize;
+    }
+
+    public function from(String $source): \Rodenastyle\StreamParser\StreamParserInterface
+    {
+        return $this->parser->from($source);
+    }
+
+    public function eachChunk(callable $function): StreamParserInterface
+    {
+        $this->onChunkCompleteCallback = $function;
+        return $this;
+    }
+
+    public function each(callable $function)
+    {
+        if ($this->onChunkCompleteCallback === null) {
+            throw new UndefinedCallbackException("No callback is set on chunk complete");
+        }
+        // decorate function to apply both its behavior and the chunk process
+        $function = function ($collection) use ($function) {
+            $this->iterationCount++;
+            $function($collection);
+
+            if ($this->iterationCount % $this->chunkSize === 0) {
+                $this->executeChunkCompleteCallback();
+            }
+        };
+        $this->parser->each($function);
+
+        // make sure no entry is left out
+        $this->processLastEntries();
+        return $this;
+    }
+
+    /**
+     * @param $this
+     */
+    protected function executeChunkCompleteCallback()
+    {
+        $this->iterationCount = 0;
+        ($this->onChunkCompleteCallback)();
+    }
+
+    protected function processLastEntries()
+    {
+        if ($this->iterationCount % $this->chunkSize !== 0) {
+            $this->executeChunkCompleteCallback();
+        }
+    }
+
+
+    /**
+     * @param int $chunkSize
+     * @return ChunkExtension
+     */
+    public function setChunkSize(int $chunkSize): ChunkExtension
+    {
+        $this->chunkSize = $chunkSize;
+        return $this;
+    }
+
+    /**
+     * @return \Rodenastyle\StreamParser\StreamParserInterface
+     */
+    public function getParser(): \Rodenastyle\StreamParser\StreamParserInterface
+    {
+        return $this->parser;
+    }
+}

--- a/src/Parsers/JSONParser.php
+++ b/src/Parsers/JSONParser.php
@@ -17,18 +17,6 @@ class JSONParser implements StreamParserInterface
 {
 	protected $reader, $source;
 
-	public function __construct()
-	{
-		Collection::macro('recursive', function () {
-			return $this->map(function ($value) {
-				if (is_array($value) || is_object($value)) {
-					return (new Collection($value))->recursive();
-				}
-				return $value;
-			});
-		});
-	}
-
 	public function from(String $source): StreamParserInterface
 	{
 		$this->source = $source;

--- a/src/StreamParser.php
+++ b/src/StreamParser.php
@@ -9,6 +9,7 @@
 namespace Rodenastyle\StreamParser;
 
 
+use Rodenastyle\StreamParser\Extensions\ChunkExtension;
 use Rodenastyle\StreamParser\Parsers\CSVParser;
 use Rodenastyle\StreamParser\Parsers\JSONParser;
 use Rodenastyle\StreamParser\Parsers\XMLParser;
@@ -41,5 +42,10 @@ class StreamParser
 
 	private function csv(String $source){
 		return (new CSVParser())->from($source);
+	}
+
+    private function chunk(StreamParserInterface $parser)
+    {
+        return new ChunkExtension($parser);
 	}
 }

--- a/src/StreamParser.php
+++ b/src/StreamParser.php
@@ -12,18 +12,34 @@ namespace Rodenastyle\StreamParser;
 use Rodenastyle\StreamParser\Parsers\CSVParser;
 use Rodenastyle\StreamParser\Parsers\JSONParser;
 use Rodenastyle\StreamParser\Parsers\XMLParser;
+use Rodenastyle\StreamParser\Traits\Facade;
+use Tightenco\Collect\Support\Collection;
 
 class StreamParser
 {
-	public static function xml(String $source){
+	use Facade;
+
+	private function __construct()
+	{
+		Collection::macro('recursive', function () {
+			return $this->map(function ($value) {
+				if (is_array($value) || is_object($value)) {
+					return (new Collection($value))->recursive();
+				}
+				return $value;
+			});
+		});
+	}
+
+	private function xml(String $source){
 		return (new XMLParser())->from($source);
 	}
 
-	public static function json(String $source){
+	private function json(String $source){
 		return (new JSONParser())->from($source);
 	}
 
-	public static function csv(String $source){
+	private function csv(String $source){
 		return (new CSVParser())->from($source);
 	}
 }

--- a/src/Traits/Facade.php
+++ b/src/Traits/Facade.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: sergio.rodenas
+ * Date: 27/6/18
+ * Time: 15:49
+ */
+
+namespace Rodenastyle\StreamParser\Traits;
+
+
+trait Facade
+{
+	public static function __callStatic($name, $arguments)
+	{
+		return (new static())->{$name}(...$arguments);
+	}
+}

--- a/tests/Extensions/ChunkParserTest.php
+++ b/tests/Extensions/ChunkParserTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Loïc Gouttefangeas <loic.gouttefangeas.pro@gmail.com>
+ * Date: 25/08/2018
+ * Time: 23:01
+ */
+
+namespace Rodenastyle\StreamParser\Test\Extensions;
+
+
+use PHPUnit\Framework\TestCase;
+use Rodenastyle\StreamParser\Exceptions\UndefinedCallbackException;
+use Rodenastyle\StreamParser\Extensions\ChunkExtension;
+use Rodenastyle\StreamParser\StreamParser;
+
+class ChunkParserTest extends TestCase
+{
+    private $stub = __DIR__ . DIRECTORY_SEPARATOR . ".." . DIRECTORY_SEPARATOR . "Stubs" . DIRECTORY_SEPARATOR . "sample.json";
+
+    public function test_extension_does_not_break_base_functionnality()
+    {
+        $count = 0;
+        $this->getParser()
+            ->eachChunk(function(){})
+            ->each(function () use (&$count) {
+            $count++;
+        });
+
+        $this->assertEquals(5, $count);
+    }
+
+    public function test_chunk_is_triggered_correct_number_of_times()
+    {
+        $iterationCount = 0;
+
+        $this->getParser()
+            ->setChunkSize(5)
+            ->eachChunk(function() use (& $iterationCount) {
+                $iterationCount++;
+            })
+            ->each(function(){});
+        $this->assertEquals(1, $iterationCount);
+    }
+
+    public function test_chunk_doesnt_forget_last_entries()
+    {
+        $iterationCount = 0;
+        $this->getParser()
+            ->setChunkSize(2)
+            ->eachChunk(function() use (& $iterationCount) {
+                $iterationCount++;
+            })
+            ->each(function(){});
+
+        // 2 chunks of 2, one chunk of 1
+        $this->assertEquals(3, $iterationCount);
+    }
+
+
+
+    public function test_it_throws_exception_if_no_callback_is_set()
+    {
+        $this->expectException(UndefinedCallbackException::class);
+        $this->getParser()
+            ->each(function(){});
+    }
+
+    /**
+     * @return ChunkExtension
+     */
+    protected function getParser(): ChunkExtension
+    {
+        return StreamParser::chunk(StreamParser::json($this->stub));
+    }
+}

--- a/tests/Parsers/CSVParserTest.php
+++ b/tests/Parsers/CSVParserTest.php
@@ -10,6 +10,7 @@ namespace Rodenastyle\StreamParser\Test\Parsers;
 
 use PHPUnit\Framework\TestCase;
 use Rodenastyle\StreamParser\StreamParser;
+use Rodenastyle\StreamParser\Parsers\CSVParser;
 use Tightenco\Collect\Support\Collection;
 
 class CSVParserTest extends TestCase
@@ -24,7 +25,7 @@ class CSVParserTest extends TestCase
 			$count++;
 		});
 
-		$this->assertEquals(5, $count);
+		$this->assertEquals(6, $count);
 	}
 
 	public function test_transforms_elements_to_collections()
@@ -41,11 +42,21 @@ class CSVParserTest extends TestCase
 			"Anthology of World Literature",
 			"Computer Dictionary",
 			"Cooking on a Budget",
-			"Great Works of Art"
+			"Great Works of Art",
+			"0"
 		];
 
-		StreamParser::csv($this->stub)->each(function($book) use ($titles){
+		$prices = [
+			'12.95',
+			'24.95',
+			'24.90',
+			'0',
+			'29.95',
+		];
+
+		StreamParser::csv($this->stub)->each(function($book) use ($titles, $prices){
 			$this->assertContains($book->get('title'), $titles);
+			$this->assertContains($book->get('price'), $prices);
 		});
 	}
 
@@ -56,5 +67,17 @@ class CSVParserTest extends TestCase
 				$this->assertInstanceOf(Collection::class, $book->get('comments'));
 			}
 		});
+	}
+
+	public function test_allow_empty_string()
+	{
+		CSVParser::$skipsEmptyLines = false;
+
+		$count = 0;
+		StreamParser::csv($this->stub)->each(function() use (&$count){
+			$count++;
+		});
+
+		$this->assertEquals(8, $count);
 	}
 }

--- a/tests/Stubs/sample.csv
+++ b/tests/Stubs/sample.csv
@@ -1,6 +1,9 @@
 title,price,comments
 The Iliad and The Odyssey,12.95,"Best translation I've read.,I like other versions better."
 Anthology of World Literature,24.95,"Needs more modern literature.,Excellent overview of world literature."
-Computer Dictionary,24.95,"A valuable resource.,"
-Cooking on a Budget,23.95,"Delicious!,"
+
+Computer Dictionary,24.90,"A valuable resource.,"
+,,
+0,0,"0,0"
+Cooking on a Budget,0,"Delicious!,"
 Great Works of Art,29.95,


### PR DESCRIPTION
Hey,

Came to say that I love the project. It tickled my fancy.
So below you'll an idea of implementation for the chunk parsing functionnality.

Seeing there are other ideas in the making, I've used a decorator as not to bloat the parser with a specific use-case functionnality.
That way if can be switched on and off at will. And it should reduce conflicts with other issues.
The facade use of the chunk extension can be tweaked, as I still feel it to be somewhat verbose. Although I tried not to go too far

However, I am not sure if this is how you envisionned the chunk parsing, so feel free to comment.
I did not want to make the user manipulate an array of the chunk, as it would go against the principle of the library ?
So the eachChunk method takes no argument

I'll be available to any feedback.
