### PR TITLE
Keep track of nesting

### DIFF
--- a/src/Parsers/XMLParser.php
+++ b/src/Parsers/XMLParser.php
@@ -46,11 +46,11 @@ class XMLParser implements StreamParserInterface
 	private function searchElement(callable $function)
 	{
 		if($this->isElement() && ! $this->shouldBeSkipped()){
-			$function($this->extractElement($this->reader->name));
+			$function($this->extractElement($this->reader->name, false, $this->reader->depth));
 		}
 	}
 
-	private function extractElement(String $elementName, $couldBeAnElementsList = false)
+	private function extractElement(String $elementName, $couldBeAnElementsList = false, int $parentDepth)
 	{
 		$elementCollection = (new Collection())->merge($this->getCurrentElementAttributes());
 
@@ -59,7 +59,7 @@ class XMLParser implements StreamParserInterface
 		}
 
 		while($this->reader->read()) {
-			if($this->isEndElement($elementName)) {
+			if($this->isEndElement($elementName) && $this->reader->depth === $parentDepth) {
 				break;
 			}
 			if($this->isValue()) {
@@ -72,10 +72,10 @@ class XMLParser implements StreamParserInterface
 			if($this->isElement()) {
 				if($couldBeAnElementsList) {
 					$foundElementName = $this->reader->name;
-					$elementCollection->push(new Collection($this->extractElement($foundElementName)));
+					$elementCollection->push(new Collection($this->extractElement($foundElementName, false, $this->reader->depth)));
 				} else {
 					$foundElementName = $this->reader->name;
-					$elementCollection->put($foundElementName, $this->extractElement($foundElementName, true));
+					$elementCollection->put($foundElementName, $this->extractElement($foundElementName, true, $this->reader->depth));
 				}
 			}
 		}

--- a/tests/Contracts/ElementDepthManagement.php
+++ b/tests/Contracts/ElementDepthManagement.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: sergio.rodenas
+ * Date: 3/6/18
+ * Time: 19:43
+ */
+
+namespace Rodenastyle\StreamParser\Test\Contracts;
+
+
+interface ElementDepthManagement
+{
+	/**
+	 *  It manages to parse child elements with same parent name
+     * 
+     *  <booklist>
+     *      <book>
+     *          <title>Hello world</title>
+     *          <book>456788</book>  <----- THIS IS ALSO PARSED
+     *      </book>
+     * </booklist>
+     * 
+	 */
+
+	public function test_it_parses_child_with_same_parent_name();
+}

--- a/tests/Parsers/XMLParserTest.php
+++ b/tests/Parsers/XMLParserTest.php
@@ -11,10 +11,11 @@ namespace Rodenastyle\StreamParser\Test\Parsers;
 use Rodenastyle\StreamParser\StreamParser;
 use Rodenastyle\StreamParser\Test\Contracts\ElementAttributesManagement;
 use Rodenastyle\StreamParser\Test\Contracts\ElementListManagement;
+use Rodenastyle\StreamParser\Test\Contracts\ElementDepthManagement;
 use Rodenastyle\StreamParser\Test\TestCase;
 use Tightenco\Collect\Support\Collection;
 
-class XMLParserTest extends TestCase implements ElementAttributesManagement, ElementListManagement {
+class XMLParserTest extends TestCase implements ElementAttributesManagement, ElementListManagement, ElementDepthManagement {
 
 	private $stub = __DIR__.DIRECTORY_SEPARATOR."..".DIRECTORY_SEPARATOR."Stubs".DIRECTORY_SEPARATOR."sample.xml";
 

--- a/tests/Parsers/XMLParserTest.php
+++ b/tests/Parsers/XMLParserTest.php
@@ -26,7 +26,7 @@ class XMLParserTest extends TestCase implements ElementAttributesManagement, Ele
 			$count++;
 		});
 
-		$this->assertEquals(5, $count);
+		$this->assertEquals(6, $count);
 	}
 
 	public function test_transforms_elements_to_collections()
@@ -43,7 +43,8 @@ class XMLParserTest extends TestCase implements ElementAttributesManagement, Ele
 			"Anthology of World Literature",
 			"Computer Dictionary",
 			"Cooking on a Budget",
-			"Great Works of Art"
+			"Great Works of Art",
+			"The Greatest Element"
 		];
 
 		StreamParser::xml($this->stub)->each(function($book) use ($titles){
@@ -67,7 +68,8 @@ class XMLParserTest extends TestCase implements ElementAttributesManagement, Ele
 			"11-000000-002",
 			"11-000000-003",
 			"11-000000-004",
-			"10-000000-999"
+			"10-000000-999",
+			"11-000000-005"
 		];
 
 		StreamParser::xml($this->stub)->each(function($book) use ($ISBNList){

--- a/tests/Parsers/XMLParserTest.php
+++ b/tests/Parsers/XMLParserTest.php
@@ -99,4 +99,12 @@ class XMLParserTest extends TestCase implements ElementAttributesManagement, Ele
 		    }
 	    });
 	}
+
+	public function test_it_parses_child_with_same_parent_name(){
+		StreamParser::xml($this->stub)->each(function($book){
+			if($book->has('book')){
+				$this->assertEquals($book->get('book'), "The nested element named like the parent");
+			}
+		});
+	}
 }

--- a/tests/Stubs/sample.xml
+++ b/tests/Stubs/sample.xml
@@ -47,4 +47,9 @@
         <title>Great Works of Art</title>
         <price>29.95</price>
     </book>
+    <book ISBN="11-000000-005">
+        <book>The nested element named like the parent</book>
+        <title>The Greatest Element</title>
+        <price>29.95</price>
+    </book>
 </bookstore>


### PR DESCRIPTION
Allows to nest elements named like parent element.
Prevents early closing of parent element.